### PR TITLE
Call the callback when `flush()` is complete in order to signal stream read end

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = Class.extend({
             // pass the file to the next plugin
             this.push(file);
             callback();
-        }, function flush() {
+        }, function flush(callback) {
             try {
                 var result = me.jsduck.doc(me.paths);
                 var output = result.output.toString();
@@ -68,6 +68,7 @@ module.exports = Class.extend({
             catch(e) {
                 throw new PluginError(PLUGIN_NAME, e.toString());
             }
+            callback();
         });
         return stream;
     }


### PR DESCRIPTION
Hey man, thanks for putting this plugin together.

Added a call to the through2 `flush()` callback in order to signal Gulp when the JSDuck task is complete. Needed to add this so that I could copy my example files in afterwards. (JSDuck clears the output directory when executed so if it's still executing when the example files are copied in, the examples get removed from it.)
